### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "brisky-core": "^1.4.1",
     "vigour-ua": "^2.0.3",
-    "vigour-util": "^3.0.0",
-    "bubleify": "0.5.1"
+    "vigour-util": "^3.0.0"
   },
   "devDependencies": {
     "ducktape": "^1.0.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during the test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
